### PR TITLE
Use CertHash switch

### DIFF
--- a/DotNet/ClickOnceAction.cs
+++ b/DotNet/ClickOnceAction.cs
@@ -300,7 +300,7 @@ namespace Inedo.BuildMasterExtensions.WindowsSdk.DotNet
                 else
                 {
                     LogInformation(string.Format("Cert with thumbprint {0} not found in local machine store, falling back to CertHash switch.", certificateHash));
-                    return string.Format("-CertHash {0} ", this.CertificateHash.Replace(" ", "").ToUpper());
+                    return string.Format("-CertHash {0} ", certificateHash);
                 }
             }
 
@@ -308,10 +308,8 @@ namespace Inedo.BuildMasterExtensions.WindowsSdk.DotNet
             {
                 return string.Format("-CertFile \"{0}\" ", certificatePath);
             }
-            else
-            {
-                return string.Format("-CertFile \"{0}\" -Password \"{1}\" ", certificatePath, certificatePassword);
-            }
+            
+            return string.Format("-CertFile \"{0}\" -Password \"{1}\" ", certificatePath, certificatePassword);
         }
 
         // A riff on Util.Files.CopyFiles, with the rename included

--- a/DotNet/ClickOnceAction.cs
+++ b/DotNet/ClickOnceAction.cs
@@ -198,7 +198,7 @@ namespace Inedo.BuildMasterExtensions.WindowsSdk.DotNet
             }
             else if (name == "SignApplication")
             {
-                //%_MAGE% -Sign %_PRJNME%.exe.manifest -CertFile %_CERT%
+                //%_MAGE% -Sign %_PRJNME%.exe.manifest -{CertFile|CertHash} %_CERT%
                 return ExecuteCommandLine(
                     GetMagePath(),
                     string.Format(
@@ -250,7 +250,7 @@ namespace Inedo.BuildMasterExtensions.WindowsSdk.DotNet
             }
             else if (name == "SignDeployment")
             {
-                //%_MAGE% -Sign %_PRJNME%.application -CertFile %_CERT%
+                //%_MAGE% -Sign %_PRJNME%.application -{CertFile|CertHash} %_CERT%
                 return ExecuteCommandLine(
                     GetMagePath(),
                     string.Format(
@@ -274,34 +274,24 @@ namespace Inedo.BuildMasterExtensions.WindowsSdk.DotNet
 
         }
 
+        /// <summary>
+        /// Gets the signing certificate switch and arguments.
+        /// </summary>
+        /// <returns>The switch and arguments.</returns>
         private string GetCertificateArguments()
         {
-            var certificatePath = this.CertificatePath;
-            var certificatePassword = this.CertificatePassword;
             if (!string.IsNullOrEmpty(this.CertificateHash))
             {
-                var certificateHash = this.CertificateHash;
-                certificateHash = certificateHash.Replace(" ", "").ToUpper();
-                var certStore = new X509Store(StoreLocation.LocalMachine);
-                certStore.Open(OpenFlags.ReadOnly);
-                var certs = certStore.Certificates.Find(X509FindType.FindByThumbprint, certificateHash, false);
-                if (certs.Count > 0)
-                {
-                    var cert = certs[0];
-                    certificatePath = Path.Combine(this.Context.TempDirectory, "Cert.pfx");
-                    var certData = cert.Export(X509ContentType.Pfx);
-                    File.WriteAllBytes(certificatePath, certData);
-                }
-                else
-                {
-                    LogWarning("Cert with thumbprint {0} not found.", certificateHash);
-                }
+                return string.Format("-CertHash {0} ", this.CertificateHash.Replace(" ", "").ToUpper());
             }
-
-            if (string.IsNullOrEmpty(certificatePassword))
-                return string.Format("-CertFile \"{0}\" ", certificatePath);
-
-            return string.Format("-CertFile \"{0}\" -Password \"{1}\" ", certificatePath, certificatePassword);
+            else if (string.IsNullOrEmpty(this.CertificatePassword))
+            {
+                return string.Format("-CertFile \"{0}\" ", this.CertificatePath);
+            }
+            else
+            {
+                return string.Format("-CertFile \"{0}\" -Password \"{1}\" ", this.CertificatePath, this.CertificatePassword);
+            }
         }
 
         // A riff on Util.Files.CopyFiles, with the rename included


### PR DESCRIPTION
Updated GetCertificateArguments to use the CertHash switch when the user provides a certificate hash (thumbnail).

Tested "-CertHash" switch.  Was successfully able to create and sign a package using a certificate hash (or thumbnail).
