### PR TITLE
Make quiet builds possible to speed up execution

### DIFF
--- a/BmBuildLogger/MSBuildLogger.cs
+++ b/BmBuildLogger/MSBuildLogger.cs
@@ -13,7 +13,7 @@ namespace Inedo.BmBuildLogger
 
         public void Initialize(IEventSource eventSource)
         {
-            eventSource.MessageRaised += HandleMessageRaised;
+            if (Verbosity > LoggerVerbosity.Quiet) eventSource.MessageRaised += HandleMessageRaised;
 
             eventSource.ProjectStarted += HandleProjectStarted;
             eventSource.ProjectFinished += HandleProjectFinished;
@@ -26,7 +26,7 @@ namespace Inedo.BmBuildLogger
 
         private static void HandleMessageRaised(object sender, BuildMessageEventArgs e)
         {
-            if (e.Importance <= MessageImportance.Normal)
+           if (e.Importance <= MessageImportance.Normal)
                 LogMessage(0, e.SenderName + ": " + e.Message);
         }
         private static void HandleProjectStarted(object sender, ProjectStartedEventArgs e) => LogMessage(10, "Building " + e.Message);

--- a/BmBuildLogger/MSBuildLogger.cs
+++ b/BmBuildLogger/MSBuildLogger.cs
@@ -26,7 +26,7 @@ namespace Inedo.BmBuildLogger
 
         private static void HandleMessageRaised(object sender, BuildMessageEventArgs e)
         {
-           if (e.Importance <= MessageImportance.Normal)
+            if (e.Importance <= MessageImportance.Normal)
                 LogMessage(0, e.SenderName + ": " + e.Message);
         }
         private static void HandleProjectStarted(object sender, ProjectStartedEventArgs e) => LogMessage(10, "Building " + e.Message);


### PR DESCRIPTION
This change makes logger to respect msbuild verbosity level set to quiet. It gives a massive speed improvement when building big applications (hundreds of projects)